### PR TITLE
Add pass-through `context` argument to allow subfolders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Action for automatic Docker image build and push
 - Custom tag option
+- Add `context` argument to allow for Dockerfiles in subfolders

--- a/build-release/action.yml
+++ b/build-release/action.yml
@@ -17,6 +17,9 @@ inputs:
   custom-tags:
     description: 'Custom tags'
     default: ''
+  context:
+    description: 'Docker build context'
+    default: '.'
 
 runs:
   using: "composite"
@@ -55,6 +58,6 @@ runs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v2
       with:
-        context: .
+        context: ${{ inputs.context }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/build-release/action.yml
+++ b/build-release/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -38,7 +38,7 @@ runs:
 
     - name: Create tags
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v5
       with:
         flavor: |
           latest=false
@@ -49,14 +49,14 @@ runs:
           ${{ inputs.custom-tags }}
 
     - name: Log in to the Container registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
         password: ${{ inputs.github-token }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v5
       with:
         context: ${{ inputs.context }}
         push: true


### PR DESCRIPTION
# Description
This adds the input variable `context`, defaulting to `.`, that is passed straight through to the [corresponding input](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs) for the `docker/build-push-action`.

I successfully used this action with [this workflow file](https://github.com/uclahs-cds/tool-Nextflow-action/blob/89119c9ba25ef1540f70dd9731ca35cba7b966ba/.github/workflows/Docker-build-release.yaml) to create https://github.com/uclahs-cds/tool-Nextflow-action/pkgs/container/nextflow-config-tests.

For good measure I also bumped up the versions of the various sub-actions to get rid of [a bunch of deprecation warnings](https://github.com/uclahs-cds/tool-Nextflow-action/actions/runs/8104940755). The https://github.com/jbutcher5/read-yaml action is still throwing warnings but has been archived, so we should either fork and fix it or find a replacement.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [x] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.