### PR TITLE
Build all branches, delete image versions when branches/tags are deleted

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Action for automatic Docker image build and push
 - Custom tag option
 - Add `context` argument to allow for Dockerfiles in subfolders
+- Delete docker versions when git branches/tags are deleted
 
 ### Changed
 - Unpack `build-release` folder
 - Replace `jbutcher5/read-yaml` with `mikefarah/yq` for YAML parsing
 - Use `${github.token}` as default value for `github-token`.
+- Require usage of <ghcr.io>, change `registry` input to `organization`
+- Build on pushes to all branches
+- Tag non-`main` branches as `branch-<branchname>`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This action will build and push images of the form `ghcr.io/<organization>/<imag
 | `main` | default branch | `dev` |
 | `mybranch` | branch | `branch-mybranch` |
 | `v1.2.3` | tag | `1.2.3` |
+
 When a git branch or tag is deleted, the corresponding docker will be deleted as well.
 
 ## Usage
@@ -62,6 +63,7 @@ The complicated `run-name` logic above controls the workflow run names listed on
 ### Inputs
 
 | Name | Default | Description |
+| ---- | ------- | ----------- |
 | `organization` | -- | The GitHub organizational host of the image. Defaults to the organization of the calling repository. |
 | `metadata-file` | `metadata.yaml` | Metadata file storing the image name. |
 | `image-name-key-path` | `.image_name` | [`yq`](https://github.com/mikefarah/yq) query for the image name within the metadata file. |

--- a/README.md
+++ b/README.md
@@ -1,20 +1,81 @@
-# Project/Repo Title
+# Docker Build Action
 
-Template Repository for the Boutros Lab general project repos. Describe a simple overview of use/purpose here.
+An Action to automatically build and push images to the [GitHub Container registry](https://github.com/features/packages).
 
 ## Description
 
-An in-depth paragraph about your project and overview of use.
+This action will build and push images of the form `ghcr.io/<organization>/<image>:<version>`. The `<version>` field is controlled by the following logic:
+
+| Pushed Ref | Type | Resulting Tag |
+| ---------- | -------------- | ----------------- |
+| `main` | default branch | `dev` |
+| `mybranch` | branch | `branch-mybranch` |
+| `v1.2.3` | tag | `1.2.3` |
+When a git branch or tag is deleted, the corresponding docker will be deleted as well.
+
+## Usage
+
+```yaml
+---
+name: Update image in GHCR
+
+run-name: >
+  ${{
+    github.event_name == 'delete' && format(
+      'Delete `{0}{1}`',
+      github.event.ref_type == 'branch' && 'branch-' || '',
+      github.event.ref
+    )
+    || github.ref == 'refs/heads/main' && 'Update `dev`'
+      || format(
+        'Update `{0}{1}`',
+        !startsWith(github.ref, 'refs/tags') && 'branch-' || '',
+        github.ref_name
+      )
+  }} docker tag
+
+on:
+  push:
+    branches-ignore: ['gh-pages']
+    tags: ['v*']
+  delete:
+
+jobs:
+  push-or-delete-image:
+    runs-on: ubuntu-latest
+    name: Update GitHub Container Registry
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: uclahs-cds/tool-Docker-action@v2
+```
+
+The complicated `run-name` logic above controls the workflow run names listed on the Actions page:
+
+| Ref Name | Ref Type | `push` Run Name | `delete` Run Name |
+| -------------------- | -------- | ----------------------------------- | ----------------------------------- |
+| Push to `main` | branch | Update `dev` docker tag | Delete `dev` docker tag |
+| Push to `mybranch` | branch | Update `branch-mybranch` docker tag | Delete `branch-mybranch` docker tag |
+| Push to `v1.2.3` tag | tag | Update `v1.2.3` docker tag | Delete `v1.2.3` docker tag |
+
+### Inputs
+
+| Name | Default | Description |
+| `organization` | -- | The GitHub organizational host of the image. Defaults to the organization of the calling repository. |
+| `metadata-file` | `metadata.yaml` | Metadata file storing the image name. |
+| `image-name-key-path` | `.image_name` | [`yq`](https://github.com/mikefarah/yq) query for the image name within the metadata file. |
+| `github-token` | `github.token`  | Token used for authentication. Requires `contents: read` for the calling repository and `packages:write` for the host organization. |
+| `custom-tags` | -- | Additional lines to add to the [docker/metadata-action `tags` argument](https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input). |
+| `context` | `.` | The docker build context. Only required if the `Dockerfile` is not in the repository root. |
 
 ## License
 
-Author: Name1(username1@mednet.ucla.edu), Name2(username2@mednet.ucla.edu)
+Author: Nicholas Wiltsie (nwiltsie@mednet.ucla.edu), Yash Patel (yashpatel@mednet.ucla.edu)
 
-[This project] is licensed under the GNU General Public License version 2. See the file LICENSE.md for the terms of the GNU GPL license.
+tool-docker-action is licensed under the GNU General Public License version 2. See the file LICENSE.md for the terms of the GNU GPL license.
 
-<one line to give the project/program's name and a brief idea of what it does.>
-
-Copyright (C) 2021 University of California Los Angeles ("Boutros Lab") All rights reserved.
+Copyright (C) 2024 University of California Los Angeles ("Boutros Lab") All rights reserved.
 
 This program is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
 

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
 
     - name: Read YAML
       id: yaml-data
-      uses: mikefarah/yq@v4
+      uses: mikefarah/yq@v4.44.2
       with:
         cmd: yq '${{ inputs.image-name-key-path }}' '${{ inputs.metadata-file }}'
 

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,9 @@
 ---
 name: 'Docker-build-release'
-description: 'Build Docker image and push to repository'
+description: 'Build Docker image and push to GHCR'
 inputs:
-  registry:
-    description: 'Registry to which image will be pushed'
-    default: ghcr.io/uclahs-cds
+  organization:
+    description: 'Organizational host for the image. Defaults to the organization of the calling repository.'
   metadata-file:
     description: 'Metadata YAML file containing information'
     default: metadata.yaml
@@ -35,11 +34,20 @@ runs:
       with:
         cmd: yq '${{ inputs.image-name-key-path }}' '${{ inputs.metadata-file }}'
 
+    - name: Parse organization
+      id: parse-org
+      shell: bash
+      env:
+        CALLING_ORGANIZATION: ${{ github.event.organization.login }}
+        INPUT_ORGANIZATION: ${{ inputs.organization }}
+      run: echo "org=${INPUT_ORGANIZATION:-$CALLING_ORGANIZATION}" >> "$GITHUB_OUTPUT"
+
     # Take this path if the event is a branch deletion
     - if: github.event_name == 'delete'
       name: Delete matching docker tags
       uses: actions/github-script@v7
       env:
+        ORGANIZATION: ${{ steps.parse-org.outputs.org }}
         IMAGE_NAME: ${{ steps.yaml-data.outputs.result }}
       with:
         script: |
@@ -54,7 +62,7 @@ runs:
       with:
         flavor: |
           latest=false
-        images: ${{ inputs.registry }}/${{ steps.yaml-data.outputs.result }}
+        images: ghcr.io/${{ steps.parse-org.outputs.org }}/${{ steps.yaml-data.outputs.result }}
         tags: |
           type=raw,enable=${{ github.ref == 'refs/heads/main' }},value=dev
           type=ref,enable=${{ github.ref != 'refs/heads/main' }},prefix=branch-,event=branch
@@ -65,7 +73,7 @@ runs:
       if: github.event_name != 'delete'
       uses: docker/login-action@v3
       with:
-        registry: ${{ inputs.registry }}
+        registry: ghcr.io/${{ steps.parse-org.outputs.org }}
         username: ${{ github.actor }}
         password: ${{ inputs.github-token }}
 
@@ -82,6 +90,7 @@ runs:
       name: Log comment with image URL
       uses: actions/github-script@v7
       env:
+        ORGANIZATION: ${{ steps.parse-org.outputs.org }}
         IMAGE_NAME: ${{ steps.yaml-data.outputs.result }}
         IMAGE_DIGEST: ${{ steps.buildpush.outputs.digest }}
       with:

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,20 @@ runs:
       with:
         cmd: yq '${{ inputs.image-name-key-path }}' '${{ inputs.metadata-file }}'
 
+    # Take this path if the event is a branch deletion
+    - if: github.event_name == 'delete'
+      name: Delete matching docker tags
+      uses: actions/github-script@v7
+      env:
+        IMAGE_NAME: ${{ steps.yaml-data.outputs.result }}
+      with:
+        script: |
+          const script = require(`${process.env['GITHUB_ACTION_PATH']}/delete-tags.js`)
+          await script({ github, context, core })
+
+    # Take this path if the event is not a deletion
     - name: Create tags
+      if: github.event_name != 'delete'
       id: meta
       uses: docker/metadata-action@v5
       with:
@@ -49,6 +62,7 @@ runs:
           ${{ inputs.custom-tags }}
 
     - name: Log in to the Container registry
+      if: github.event_name != 'delete'
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.registry }}
@@ -57,13 +71,15 @@ runs:
 
     - name: Build and push Docker image
       id: buildpush
+      if: github.event_name != 'delete'
       uses: docker/build-push-action@v5
       with:
         context: ${{ inputs.context }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
 
-    - name: Log comment with image URL
+    - if: github.event_name != 'delete'
+      name: Log comment with image URL
       uses: actions/github-script@v7
       env:
         IMAGE_NAME: ${{ steps.yaml-data.outputs.result }}

--- a/action.yml
+++ b/action.yml
@@ -43,8 +43,9 @@ runs:
           latest=false
         images: ${{ inputs.registry }}/${{ steps.yaml-data.outputs.result }}
         tags: |
-          type=raw,enable=${{github.event_name == 'push'}},value=dev,event=branch
-          type=match,pattern=v(.*),group=1
+          type=raw,enable=${{ github.ref == 'refs/heads/main' }},value=dev
+          type=ref,enable=${{ github.ref != 'refs/heads/main' }},prefix=branch-,event=branch
+          type=semver,pattern={{version}}
           ${{ inputs.custom-tags }}
 
     - name: Log in to the Container registry

--- a/action.yml
+++ b/action.yml
@@ -56,8 +56,19 @@ runs:
         password: ${{ inputs.github-token }}
 
     - name: Build and push Docker image
+      id: buildpush
       uses: docker/build-push-action@v5
       with:
         context: ${{ inputs.context }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
+
+    - name: Log comment with image URL
+      uses: actions/github-script@v7
+      env:
+        IMAGE_NAME: ${{ steps.yaml-data.outputs.result }}
+        IMAGE_DIGEST: ${{ steps.buildpush.outputs.digest }}
+      with:
+        script: |
+          const script = require(`${process.env['GITHUB_ACTION_PATH']}/post-url.js`)
+          await script({ github, context, core })

--- a/delete-tags.js
+++ b/delete-tags.js
@@ -1,5 +1,5 @@
 module.exports = async ({ github, context, core }) => {
-  const { IMAGE_NAME } = process.env
+  const { IMAGE_NAME, ORGANIZATION } = process.env
 
   let tagName
 
@@ -15,7 +15,7 @@ module.exports = async ({ github, context, core }) => {
     github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
       package_type: 'container',
       package_name: IMAGE_NAME,
-      org: context.payload.organization.login
+      org: ORGANIZATION
     })) {
     for (const version of response.data) {
       const tags = version.metadata?.container?.tags
@@ -30,7 +30,7 @@ module.exports = async ({ github, context, core }) => {
         await github.rest.packages.deletePackageVersionForOrg({
           package_type: 'container',
           package_name: IMAGE_NAME,
-          org: context.payload.organization.login,
+          org: ORGANIZATION,
           package_version_id: version.id
         })
 

--- a/delete-tags.js
+++ b/delete-tags.js
@@ -1,0 +1,49 @@
+module.exports = async ({ github, context, core }) => {
+  const { IMAGE_NAME } = process.env
+
+  let tagName
+
+  if (context.payload.ref_type === 'branch') {
+    tagName = `branch-${context.payload.ref}`
+  } else {
+    tagName = context.payload.ref.match(/^v(.*)$/)[1]
+  }
+
+  let didDelete = false
+
+  for await (const response of github.paginate.iterator(
+    github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
+      package_type: 'container',
+      package_name: IMAGE_NAME,
+      org: context.payload.organization.login
+    })) {
+    for (const version of response.data) {
+      const tags = version.metadata?.container?.tags
+      if (tags?.includes(tagName)) {
+        core.notice(`Package version ${version.html_url} matches tag ${tagName} and will be deleted`)
+
+        const otherTags = tags.filter((tag) => tag !== tagName)
+        if (otherTags.length) {
+          core.warning(`Image version has other tags that will be lost: ${otherTags}`)
+        }
+
+        await github.rest.packages.deletePackageVersionForOrg({
+          package_type: 'container',
+          package_name: IMAGE_NAME,
+          org: context.payload.organization.login,
+          package_version_id: version.id
+        })
+
+        didDelete = true
+        break
+      }
+    }
+    if (didDelete) {
+      break
+    }
+  }
+
+  if (!didDelete) {
+    core.warning(`Did not find version tagged ${tagName}`)
+  }
+}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,8 +1,13 @@
 ---
-Category: ''  # shoule be one of docker/pipeline/project/template/tool/training/users
-Description: ''  # Description of why the repository exists
-Maintainers: ['someone@mednet.ucla.edu', 'someoneelse@mednet.ucla.edu']  # email address of maintainers
-Contributors: 'Xavier Hernandez'  # Full names of contributors
-Languages: ['R', 'perl', 'nextflow']  # programming languages used
-Dependencies: 'BPG'  # packages, tools that repo needs to run
-References: ''  # is the tool/dependencies published, is there a confluence page
+Category: tool
+Description: GitHub Action to build and deploy docker images
+Maintainers:
+  - nwiltsie@mednet.ucla.edu
+Contributors:
+  - Nicholas Wiltsie
+  - Yash Patel
+Languages:
+  - bash
+  - javascript
+Dependencies:
+References:

--- a/post-url.js
+++ b/post-url.js
@@ -1,11 +1,11 @@
 module.exports = async ({ github, context, core }) => {
-  const { IMAGE_NAME, IMAGE_DIGEST } = process.env
+  const { ORGANIZATION, IMAGE_NAME, IMAGE_DIGEST } = process.env
 
   for await (const response of github.paginate.iterator(
     github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
       package_type: 'container',
       package_name: IMAGE_NAME,
-      org: context.payload.organization.login
+      org: ORGANIZATION
     })) {
     for (const version of response.data) {
       if (version.name === IMAGE_DIGEST) {

--- a/post-url.js
+++ b/post-url.js
@@ -1,0 +1,19 @@
+module.exports = async ({ github, context, core }) => {
+  const { IMAGE_NAME, IMAGE_DIGEST } = process.env
+
+  for await (const response of github.paginate.iterator(
+    github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
+      package_type: 'container',
+      package_name: IMAGE_NAME,
+      org: context.payload.organization.login
+    })) {
+    for (const version of response.data) {
+      if (version.name === IMAGE_DIGEST) {
+        core.notice(`Uploaded new image ${version.html_url}`)
+        return
+      }
+    }
+  }
+
+  core.error('Could not find URL for new image!')
+}


### PR DESCRIPTION
# Description
This is a major overhaul of this Action, intended to be released as `v2.0.0` (see plan from #12). The gist of these changes is that the Action manages the full lifecycle of images in GHCR: it will now build and deploy images for all branches of the repository, as well as all SemVer tags. When a branch or tag is deleted from GitHub, the corresponding image version is deleted from the container registry. (That is #13, but I'm not going to close that issue until the `refactor-base` branch is merged back into `main`).

The git SemVer tag `v1.2.3` will result in the docker version `1.2.3` (note the lack of `v`). 

The git branch `foobar` will result in the docker version `branch-foobar`. The one exception to this behavior is that the `main` branch will map to `dev` - that's in line with the current behavior of this Action.

> [!NOTE]  
> The default branch name is hard-coded as `main`. `docker/metadata-action` has an [`{{is_default_branch}}`](https://github.com/docker/metadata-action?tab=readme-ov-file#is_default_branch) expression, but unfortunately there is currently [no way to negate it](https://github.com/docker/metadata-action/issues/247).

### Testing

I tested this Action with a fresh repository - the assorted runs can be seen [here](https://github.com/uclahs-cds/docker-internal-tests/actions/workflows/Docker-build-release.yaml). The example workflow in the README sets the [`run-name`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#run-name) to a useful value:

<img width="593" alt="Screenshot 2024-06-24 at 12 00 26 PM" src="https://github.com/uclahs-cds/tool-Docker-action/assets/829731/9bd94224-4825-4963-9997-8802a64e679a">

Individual workflow runs will emit annotations linking to the newly-created or deleted image versions:

<img width="787" alt="Screenshot 2024-06-24 at 12 00 43 PM" src="https://github.com/uclahs-cds/tool-Docker-action/assets/829731/9d015cd4-4963-44f7-834a-29c6a826c039">

<img width="1038" alt="Screenshot 2024-06-24 at 12 00 58 PM" src="https://github.com/uclahs-cds/tool-Docker-action/assets/829731/9744f73e-0434-43b2-aff0-7f80818a4fb2">

### Errata

* The image deletion logic only works for GHCR, so our default usage of <ghcr.io> is now a required usage. I replaced the `registry` input (default `ghcr.io/uclahs-cds`) with an `organization` input (defaults to the organization of the calling repository, usually `uclahs-cds` for us).
* The `run-name` for tags (e.g. "Update `v0.0.8` docker tag") incorrectly includes the leading `v`. [GitHub Expressions](https://docs.github.com/en/actions/learn-github-actions/expressions) don't have a `substring` function, and I couldn't figure out any way to abuse the existing functions to replicate it.

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.