### PR TITLE
Add non-semver-tags input argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Custom tag option
 - Add `context` argument to allow for Dockerfiles in subfolders
 - Delete docker versions when git branches/tags are deleted
+- Add `non-semver-tags` argument to allow building on non-semver tags
 
 ### Changed
 - Unpack `build-release` folder

--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ This action will build and push images of the form `ghcr.io/<organization>/<imag
 | `main` | default branch | `dev` |
 | `mybranch` | branch | `branch-mybranch` |
 | `v1.2.3` | tag | `1.2.3` |
+| `v3-beta` (requires `non-semver-tags`) | tag | `3-beta` |
 
 When a git branch or tag is deleted, the corresponding docker will be deleted as well.
+
+### Version Tag Formats
+
+By default this Action only recognizes tags in SemVer format (e.g. `v1.2.3-rc.1`). To allow non-SemVer tags (e.g. `v3-beta`), set the `non-semver-tags` input to `true`. All tags must still start with a `v` to be recognized.
 
 ## Usage
 
@@ -70,6 +75,7 @@ The complicated `run-name` logic above controls the workflow run names listed on
 | `github-token` | `github.token`  | Token used for authentication. Requires `contents: read` for the calling repository and `packages:write` for the host organization. |
 | `custom-tags` | -- | Additional lines to add to the [docker/metadata-action `tags` argument](https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input). |
 | `context` | `.` | The docker build context. Only required if the `Dockerfile` is not in the repository root. |
+| `non-semver-tags` | -- | If set to a non-empty string, non-SemVer tags will be recognized. |
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   context:
     description: 'Docker build context'
     default: '.'
+  non-semver-tags:
+    description: 'If set to any value, build all tags beginning with v'
+    default: ''
 
 runs:
   using: "composite"
@@ -67,6 +70,7 @@ runs:
           type=raw,enable=${{ github.ref == 'refs/heads/main' }},value=dev
           type=ref,enable=${{ github.ref != 'refs/heads/main' }},prefix=branch-,event=branch
           type=semver,pattern={{version}}
+          type=match,enable=${{ inputs.non-semver-tags != '' }},pattern=v(.*),group=1
           ${{ inputs.custom-tags }}
 
     - name: Log in to the Container registry


### PR DESCRIPTION
# Description
This closes #17 by adding a `non-semver-tags` argument. If that argument is given any value, the [docker/metadata-action](https://github.com/docker/metadata-action) gets the additional docker tag format `type=match,pattern=v(.*),group=1`. That tag format will ensure that any git tag of the form `vX` will result in a docker tag of the form `X`.

I tested this with my trusty [docker-internal-tests](https://github.com/uclahs-cds/docker-internal-tests) repository. When I [had this workflow](https://github.com/uclahs-cds/docker-internal-tests/commit/bd474cf533f8628536e6c58ca1aa3a983a4d2fac)...

```yaml
    steps:
      - uses: uclahs-cds/tool-Docker-action@dev
        with:
          non-semver-tags: true
```

... and tagged it as `v0.0.5c`, the workflow [ran successfully](https://github.com/uclahs-cds/docker-internal-tests/actions/runs/10378019780/job/28733455397) and pushed the [corresponding tag](https://github.com/uclahs-cds/docker-internal-tests/pkgs/container/internal-tests/257620708?tag=0.0.5c).

> [!NOTE]
> As you can see I technically used the `dev` branch and not `nwiltsie-arg-for-non-semver`, but that's just to make future testing with that repository easier. The [workflow logs](https://github.com/uclahs-cds/docker-internal-tests/actions/runs/10378019780/job/28733455397#step:1:25) show that it used 87e99e2cb9d0588d91f4597b02dc1647e2722f5d.

When I [removed the argument](https://github.com/uclahs-cds/docker-internal-tests/commit/2dba132958687328b63e148200a65ea2010399a6) and tagged it as `v0.0.5d`, it [failed](https://github.com/uclahs-cds/docker-internal-tests/actions/runs/10378044302) with the error from #17.

### Closes #17 

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.