### PR TITLE
Handle `/` in tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Require usage of <ghcr.io>, change `registry` input to `organization`
 - Build on pushes to all branches
 - Tag non-`main` branches as `branch-<branchname>`
+- Handle `/` characters in tags when branch names contain them

--- a/delete-tags.js
+++ b/delete-tags.js
@@ -4,7 +4,7 @@ module.exports = async ({ github, context, core }) => {
   let tagName
 
   if (context.payload.ref_type === 'branch') {
-    tagName = `branch-${context.payload.ref}`
+    tagName = `branch-${context.payload.ref.replace('/', '-')}`
   } else {
     tagName = context.payload.ref.match(/^v(.*)$/)[1]
   }


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->

For PRs where the branch name contains a `/` (like dependabot PRs), the tag created replaces the `/` with `-`. The deletion workflow looks for the tag with the `/` and fails to find and delete the tag on PR closure. Updating the delete function to perform the replacement

Example: https://github.com/uclahs-cds/tool-SRC-util/actions/runs/11411848998

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

