### PR TITLE
Prepare for version `2.1.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
+
 All notable changes to the tool_name Docker file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
----
-
-## [Unreleased]
+## [2.1.1] - 2024-10-18
 
 ### Added
+
 - Action for automatic Docker image build and push
 - Custom tag option
 - Add `context` argument to allow for Dockerfiles in subfolders
@@ -17,10 +17,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `non-semver-tags` argument to allow building on non-semver tags
 
 ### Changed
+
 - Unpack `build-release` folder
 - Replace `jbutcher5/read-yaml` with `mikefarah/yq` for YAML parsing
 - Use `${github.token}` as default value for `github-token`.
-- Require usage of <ghcr.io>, change `registry` input to `organization`
+- Require usage of \<<http://ghcr.io>>, change `registry` input to `organization`
 - Build on pushes to all branches
 - Tag non-`main` branches as `branch-<branchname>`
 - Handle `/` characters in tags when branch names contain them
+
+[2.1.1]: https://github.com/uclahs-cds/tool-Docker-action/releases/tag/v2.1.1


### PR DESCRIPTION
Update CHANGELOG in preparation for release **2.1.1**.

Merging this PR will trigger another workflow to create the release tag **v2.1.1**.

| Input | Value |
| ----- | ----- |
| Actor | @nwiltsie |
| Branch | `main` |
| Bump Type | `patch` |
