### PR TITLE
Add optional `file` input to specify Dockerfile name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `context` argument to allow for Dockerfiles in subfolders
 - Delete docker versions when git branches/tags are deleted
 - Add `non-semver-tags` argument to allow building on non-semver tags
+- Add optional `file` argument to pass through to docker/build-push-action
 
 ### Changed
 - Unpack `build-release` folder

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The complicated `run-name` logic above controls the workflow run names listed on
 | `github-token` | `github.token`  | Token used for authentication. Requires `contents: read` for the calling repository and `packages:write` for the host organization. |
 | `custom-tags` | -- | Additional lines to add to the [docker/metadata-action `tags` argument](https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input). |
 | `context` | `.` | The docker build context. Only required if the `Dockerfile` is not in the repository root. |
+| `file` | `''` | The Dockerfile to build. The default (empty string) is treated as `${context}/Dockerfile`. |
 | `non-semver-tags` | -- | If set to a non-empty string, non-SemVer tags will be recognized. |
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,7 @@ runs:
     - name: Set file argument (conditionally)
       id: file_input
       if: inputs.file != ''
+      shell: bash
       run: echo "file=${{ inputs.file }}" >> "$GITHUB_OUTPUT"
 
     - name: Build and push Docker image

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
     default: '.'
   file:
     description: 'Dockerfile to build. Defaults to ${context}/Dockerfile'
-    default: ''
+    required: false
   non-semver-tags:
     description: 'If set to any value, build all tags beginning with v'
     default: ''
@@ -84,12 +84,6 @@ runs:
         username: ${{ github.actor }}
         password: ${{ inputs.github-token }}
 
-    - name: Set file argument (conditionally)
-      id: file_input
-      if: inputs.file != ''
-      shell: bash
-      run: echo "file=${{ inputs.file }}" >> "$GITHUB_OUTPUT"
-
     - name: Build and push Docker image
       id: buildpush
       if: github.event_name != 'delete'
@@ -98,7 +92,7 @@ runs:
         context: ${{ inputs.context }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
-        file: ${{ steps.file_input.outputs.file }}
+        file: ${{ inputs.file }}
 
     - if: github.event_name != 'delete'
       name: Log comment with image URL

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   context:
     description: 'Docker build context'
     default: '.'
+  file:
+    description: 'Dockerfile to build. Defaults to ${context}/Dockerfile'
+    default: ''
   non-semver-tags:
     description: 'If set to any value, build all tags beginning with v'
     default: ''
@@ -81,6 +84,11 @@ runs:
         username: ${{ github.actor }}
         password: ${{ inputs.github-token }}
 
+    - name: Set file argument (conditionally)
+      id: file_input
+      if: inputs.file != ''
+      run: echo "file=${{ inputs.file }}" >> "$GITHUB_OUTPUT"
+
     - name: Build and push Docker image
       id: buildpush
       if: github.event_name != 'delete'
@@ -89,6 +97,7 @@ runs:
         context: ${{ inputs.context }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}
+        file: ${{ steps.file_input.outputs.file }}
 
     - if: github.event_name != 'delete'
       name: Log comment with image URL


### PR DESCRIPTION
# Description

This adds a `file` input argument that is passed directly on to the [same argument](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs) in `docker/build-push-action`. This will let us use non-standard names for the Dockerfiles and have multiple Dockerfiles in the same directory.

In what feels like a rare bit of good design, we can unconditionally supply the `file` argument to the build action, but it will only actually be passed on if it has a value. That makes this change backwards-compatible - no current users will notice any difference.

Here are two runs of this action on my trusty testing repo:

### `file` given:

Workflow: https://github.com/uclahs-cds/docker-internal-tests/actions/runs/13556390576

Built image: https://github.com/uclahs-cds/docker-internal-tests/pkgs/container/internal-tests/363713099

Note that the maintainer is `Nicholas Wiltsie's Evil Twin`, as specified in [the alternate Dockerfile](https://github.com/uclahs-cds/docker-internal-tests/blob/75abd286867b89823b89555f432d4eb81878b4b4/Dockerfile-other).

### `file` not given:

Workflow: https://github.com/uclahs-cds/docker-internal-tests/actions/runs/13572207618

Built image: https://github.com/orgs/uclahs-cds/packages/container/internal-tests/363711813

In this case the maintainer is `Nicholas Wiltsie` (not my evil twin), as specified in the [standard Dockerfile](https://github.com/uclahs-cds/docker-internal-tests/blob/75abd286867b89823b89555f432d4eb81878b4b4/Dockerfile).

# Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [x] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [x] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [x] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [x] I have set up or verified the `main` branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.
- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [x] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.